### PR TITLE
Allow user to specify an S3 prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle
+build/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The second step of this approach is very straightforward. But when it comes to t
 
 **[Fast S3 Backup Data Download Utility]**
 
-1. Download the most recent release (version 3.0) of .jar file from [here](https://github.com/yabinmeng/opscs3restore/releases/download/3.0/opscs3restore-3.0-SNAPSHOT.jar)
+1. Download the most recent release (version 3.1) of .jar file from [here](https://github.com/yabinmeng/opscs3restore/releases/download/3.1/opscs3restore-3.1-SNAPSHOT.jar)
 
 2. Download the example configuration file (opsc_s3_config.properties) from [here](https://github.com/yabinmeng/opscs3restore/blob/master/src/main/resources/opsc_s3_config.properties)
 
@@ -38,7 +38,7 @@ java
   [-Daws.secretKey=<your_aws_secret_key>]
   [-Djavax.net.ssl.trustStore=<client_truststore>] 
   [-Djavax.net.ssl.trustStorePassword=<client_truststore_password>]
-  -jar ./opscs3restore-3.0-SNAPSHOT.jar com.dsetools.DseOpscS3Restore 
+  -jar ./opscs3restore-3.1-SNAPSHOT.jar com.dsetools.DseOpscS3Restore 
   -l <all|DC:"<DC_name>"|>me[:"<dsenode_host_id_string>"]> 
   -c <opsc_s3_configure.properties_full_path> 
   -d <concurrent_downloading_thread_num> 
@@ -167,6 +167,7 @@ ip_matching_nic: <NIC_name_for_IP_matching>
 use_ssl: <true | false>
 use_auth: <true | false>
 file_size_chk: <true | false>
+s3_prefix: <S3_prefix>
 ```
 Most of these items are straightforward and I'll explain some of them a little bit more.
 
@@ -185,6 +186,8 @@ Most of these items are straightforward and I'll explain some of them a little b
 * "user_auth" is ONLY relevant when DSE authentication is enabled. When true, "-u <cassandra_user_name>" and "-p <cassandra_user_password>" options must be provided.
 
 * "file_size_chk": Whether to bypass backup file size check during the download. When setting to false (default), the utility doesn't check and display file size for each to-be-restored backup files. This can be beneficial for overall performance.
+
+* `s3_prefix`: Typically, scheduled backups with an S3 destination are not configured in Opscenter with a prefix, so that snapshots are located at `s3://my-backup-bucket/snapshots`. If your configuration includes a prefix, configuring this parameter allows you to access snapshots located at a non-standard prefix. For example, configure `some-prefix` here to download snapshots from `s3://my-backup-bucket/some-prefix/snapshots`
 
 ## 2.3. Filter OpsCenter S3 backup SSTables by keyspace, table, and backup_time
 
@@ -271,7 +274,7 @@ The "-cls <true|false>" option controls whether to clear the local download dire
 java 
   -Daws.accessKeyId=<aws_accesskey_id> 
   -Daws.secretKey=<aws_secret_key> 
-  -jar ./opscs3restore-3.0-SNAPSHOT.jar com.dsetools.DseOpscS3Restore 
+  -jar ./opscs3restore-3.1-SNAPSHOT.jar com.dsetools.DseOpscS3Restore 
   -c ./opsc_s3_config.properties
   -l all 
   -k testks 
@@ -284,7 +287,7 @@ java
 java 
   -Daws.accessKeyId=<aws_accesskey_id> 
   -Daws.secretKey=<aws_secret_key> 
-  -jar ./opscs3restore-3.0-SNAPSHOT.jar com.dsetools.DseOpscS3Restore 
+  -jar ./opscs3restore-3.1-SNAPSHOT.jar com.dsetools.DseOpscS3Restore 
   -c ./opsc_s3_config.properties
   -l me
   -k testks1 
@@ -296,7 +299,7 @@ java
 java 
   -Daws.accessKeyId=<aws_accesskey_id> 
   -Daws.secretKey=<aws_secret_key> 
-  -jar ./opscs3restore-3.0-SNAPSHOT.jar com.dsetools.DseOpscS3Restore 
+  -jar ./opscs3restore-3.1-SNAPSHOT.jar com.dsetools.DseOpscS3Restore 
   -c ./opsc_s3_config.properties 
   -l me:"10409aec-241c-4a79-a707-2d3e4951dbf6" 
   -d 5
@@ -357,4 +360,12 @@ List and download OpsCenter S3 backup items for specified host (10409aec-241c-4a
      [Thread 0] download of "snapshots/10409aec-241c-4a79-a707-2d3e4951dbf6/sstables/830be0b989458a7cc65257332109d5fc-mc-1-big-Summary.db[keyspace: testks; table: singers]" completed
         >>> 92 of 92 bytes transferred (100.00%)
    - Existing Thread 0 at 2018-07-10 04:16:06 (duration: 1 seconds): 6 of 6 s3 objects downloaded, 0 failed.
+```
+
+# Building and contributing
+
+To build with Gradle 7.0.2, run
+
+```
+gradle shadowJar
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,16 @@
 group 'com.dsetools'
-version '3.0-SNAPSHOT'
+version '3.1-SNAPSHOT'
 
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
+    }
+}
+
+apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'java'
 
 sourceCompatibility = 1.8
@@ -9,38 +19,28 @@ repositories {
     mavenCentral()
 }
 
-jar {
-    manifest {
-        attributes "Main-Class": "com.dsetools.DseOpscS3Restore"
-    }
-
-    from {
-        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
-    }
-}
-
 dependencies {
     // https://mvnrepository.com/artifact/com.datastax.dse/dse-java-driver-core
-    compile group: 'com.datastax.dse', name: 'dse-java-driver-core', version: '1.6.7'
+    implementation 'com.datastax.dse:dse-java-driver-core:1.6.7'
 
     // https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3
-    compile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.360'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.11.360'
 
     // https://mvnrepository.com/artifact/commons-io/commons-io
-    compile group: 'commons-io', name: 'commons-io', version: '2.6'
+    implementation 'commons-io:commons-io:2.6'
 
     // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'
+    implementation 'org.apache.commons:commons-lang3:3.7'
 
     // https://mvnrepository.com/artifact/commons-cli/commons-cli
-    compile group: 'commons-cli', name: 'commons-cli', version: '1.4'
+    implementation 'commons-cli:commons-cli:1.4'
 
     // https://mvnrepository.com/artifact/ch.qos.logback/logback-core
-    compile group: 'ch.qos.logback', name: 'logback-core', version: '1.2.3'
+    implementation 'ch.qos.logback:logback-core:1.2.3'
 
     // https://mvnrepository.com/artifact/ch.qos.logback/logback-classic
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    implementation 'ch.qos.logback:logback-classic:1.2.3'
 
     // https://mvnrepository.com/artifact/com.googlecode.json-simple/json-simple
-    compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+    implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,9 @@ buildscript {
 
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'java'
+apply plugin: 'application'
+
+mainClassName = 'com.dsetools.DseOpscS3Restore'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/com/dsetools/DseOpscS3Restore.java
+++ b/src/main/java/com/dsetools/DseOpscS3Restore.java
@@ -303,42 +303,15 @@ public class DseOpscS3Restore {
             Iterator iterator = jsonItemArr.iterator();
 
             while (iterator.hasNext()) {
-                String jsonItemContent = (String) ((JSONObject)iterator.next()).toJSONString();
-                jsonItemContent = jsonItemContent.substring(1, jsonItemContent.length() -1 );
+              JSONObject jsonSsTable = (JSONObject)iterator.next();
 
-                String[] keyValuePairs = jsonItemContent.split(",");
+              String ssTableName = (String)jsonSsTable.get("name");
+              String uniquifierStr = (String)jsonSsTable.get("uniquifier");
+              String keyspaceName = (String)jsonSsTable.get("keyspace");
+              String tableName = (String)jsonSsTable.get("cf");
+              String ssTableVersion = (String)jsonSsTable.get("version");
 
-                String ssTableName = "";
-                String uniquifierStr = "";
-                String keyspaceName = "";
-                String tableName = "";
-                String ssTableVersion = "";
-
-                for ( String keyValuePair :  keyValuePairs ) {
-                    String key = keyValuePair.split(":")[0];
-                    String value = keyValuePair.split(":")[1];
-
-                    key = key.substring(1, key.length() - 1 );
-                    value = value.substring(1, value.length() - 1);
-
-                    if ( key.equalsIgnoreCase("uniquifier") ) {
-                        uniquifierStr = value;
-                    }
-                    else if ( key.equalsIgnoreCase("version") ) {
-                        ssTableVersion = value;
-                    }
-                    else if ( key.equalsIgnoreCase("keyspace") ) {
-                        keyspaceName = value;
-                    }
-                    else if ( key.equalsIgnoreCase("cf") ) {
-                        tableName = value;
-                    }
-                    else if ( key.equalsIgnoreCase("name") ) {
-                        ssTableName = value;
-                    }
-                }
-
-                opscObjMaps.put(ssTableName, keyspaceName + ":" + tableName + ":" + uniquifierStr + ":" + ssTableVersion);
+              opscObjMaps.put(ssTableName, keyspaceName + ":" + tableName + ":" + uniquifierStr + ":" + ssTableVersion);
             }
         }
         catch (Exception e) {

--- a/src/main/java/com/dsetools/DseOpscS3RestoreUtils.java
+++ b/src/main/java/com/dsetools/DseOpscS3RestoreUtils.java
@@ -17,6 +17,7 @@ public class DseOpscS3RestoreUtils {
     static String CFG_KEY_USER_AUTH = "user_auth";
     static String CFG_KEY_FILE_SIZE_CHK = "file_size_chk";
     static String CFG_KEY_FILE_DSE_48 = "DSE_48";
+    static String CFG_KEY_S3_PREFIX = "s3_prefix";
 
     static String JAVA_SSL_TRUSTSTORE_PROP = "javax.net.ssl.trustStore";
     static String JAVA_SSL_TRUSTSTORE_PASS_PROP = "javax.net.ssl.trustStorePassword";


### PR DESCRIPTION
As a user, I would like to be able to specify a prefix when my scheduled backups have an S3 bucket configured with a non-standard location, i.e. `my-bucket/my-prefix` rather than `my-bucket`. If my snapshots are located in `my-bucket/my-prefix/snapshots`, I should still be able to restore from them.

Thanks for making such a great tool! :tulip: